### PR TITLE
Add dynamic latency emulation to a worker thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Note: PCI device ID (e.g., 0000:01:00.0) depends on the hardware configuration.
 
 - Shuhei Aketa, Takahiro Hirofuchi, Ryousei Takano, "DEMU: A DPDK-based Network Latency Emulator," The 23rd IEEE International Symposium on Local and Metropolitan Area Networks, pp.1-6, June 2017. [[IEEE Explore](https://ieeexplore.ieee.org/document/7972145)]
 - Kanon Sasaki, Takahiro Hirofuchi, Saneyasu Yamaguchi, Ryousei Takano, "An Accurate Packet Loss Emulation on a DPDK-based Network Emulator," The 15th Asian Internet Engineering Conference, pp.1-8, August 2019. [[ACM DL](https://dl.acm.org/citation.cfm?id=3343635)]
-- Chayapon Puakalong, Vasaka Visoottiviseth,  Ryousei Takano, Assadarat Khurat1, Wudichart Sawangphol, "Implementation of Bandwidth Emulation of DEMU," PRAGMA 37 Workshop (poster), September 2019. (To appear)
+- Chayapon Puakalong, Ryousei Takano, Vasaka Visoottiviseth, Assadarat Khurat1, Wudichart Sawangphol, "A Network Bandwidth Limitation with the DEMU Network Emulator," The 10th IEEE Symposium on Computer Applications & Industrial Electronics, April 2020. (To appear)
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -132,16 +132,17 @@ Note: PCI device ID (e.g., 0000:01:00.0) depends on the hardware configuration.
 
 
 
-## Documents
+## Publications
 
 - Shuhei Aketa, Takahiro Hirofuchi, Ryousei Takano, "DEMU: A DPDK-based Network Latency Emulator," The 23rd IEEE International Symposium on Local and Metropolitan Area Networks, pp.1-6, June 2017. [[IEEE Explore](https://ieeexplore.ieee.org/document/7972145)]
-- Kanon Sasaki, Takahiro Hirofuchi, Saneyasu Yamaguchi, Ryousei Takano, "An Accurate Packet Loss Emulation on a DPDK-based Network Emulator," The 15th Asian Internet Engineering Conference, pp.1-8, August 2019. (To appear)
+- Kanon Sasaki, Takahiro Hirofuchi, Saneyasu Yamaguchi, Ryousei Takano, "An Accurate Packet Loss Emulation on a DPDK-based Network Emulator," The 15th Asian Internet Engineering Conference, pp.1-8, August 2019. [[ACM DL](https://dl.acm.org/citation.cfm?id=3343635)]
+- Chayapon Puakalong, Vasaka Visoottiviseth,  Ryousei Takano, Assadarat Khurat1, Wudichart Sawangphol, "Implementation of Bandwidth Emulation of DEMU," PRAGMA 37 Workshop (poster), September 2019. (To appear)
 
 
 ## Contributors
 
-- Shuhei AKETA, Ritsumeikan University
-- Kanon SASAKI, Kougakuin University
+- Shuhei Aketa, Ritsumeikan University
+- Kanon Sasaki, Kougakuin University
 - Chayapon Puakalong, Mahidol University
 - Takahiro Hirofuchi, AIST
 - Ryousei Takano, AIST

--- a/main.c
+++ b/main.c
@@ -163,7 +163,7 @@ struct rte_ring *rx_to_workers2;
 struct rte_ring *workers_to_tx;
 struct rte_ring *workers_to_tx2;
 
-static uint64_t delayed_value = 0; 
+static uint64_t delayed_time_in_us = 0; 
 static uint64_t delayed_jitter = 0; 
 static uint64_t delayed_time = 0;
 
@@ -276,7 +276,7 @@ static void
 delay_timer_cb(__attribute__((unused)) struct rte_timer *tmpTime, __attribute__((unused)) void *arg)
 {
 	//dynamic latency changes latency by normal distribution with delayed jitter as a standard deviation.
-	delayed_time = (rte_get_tsc_hz() + US_PER_S - 1) / US_PER_S * normal_distribution(delayed_value, delayed_jitter);
+	delayed_time = (rte_get_tsc_hz() + US_PER_S - 1) / US_PER_S * normal_distribution(delayed_time_in_us, delayed_jitter);
 }
 static void
 demu_timer_loop(void)
@@ -302,7 +302,7 @@ demu_timer_loop(void)
 		rte_timer_init(&delay_timer);
 		rte_timer_reset(&delay_timer, hz, PERIODICAL, lcore_id, delay_timer_cb, NULL);
 
-		RTE_LOG(INFO, DEMU, "  Delayed time is %lu us with delay jitter %lu us\n", delayed_value, delayed_jitter);
+		RTE_LOG(INFO, DEMU, "  Delayed time is %lu us with delay jitter %lu us\n", delayed_time_in_us, delayed_jitter);
 	}
 
 
@@ -646,7 +646,7 @@ demu_parse_args(int argc, char **argv)
 				}
 				
 				/* Global variable for values */
-				delayed_value = val;
+				delayed_time_in_us = val;
 				delayed_time = (rte_get_tsc_hz() + US_PER_S - 1) / US_PER_S * val;
 				break;
 


### PR DESCRIPTION
I added the timer function that can emulate dynamic latency.
There are 2 types of dynamic latency emulation.
- switch latency from delayed_val and delayed_val/2 every 5s
- changes latency by uniform distribution with 10% variances from delayed_time

Because of an insufficient CPU core, I implemented this function on a worker thread.